### PR TITLE
Add JournalEntry interface

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).ts'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' --fix",
     "format": "prettier --write 'src/**/*.{ts,json}'",
-    "test": "node test-api-contract.js"
+    "test": "jest && node test-api-contract.js"
   },
   "dependencies": {
     "@azure/cosmos": "^3.17.3",

--- a/backend/src/journals.test.ts
+++ b/backend/src/journals.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+import { createJournalRouter, JournalEntry } from './journals';
+
+describe('journals routes', () => {
+  const container = {
+    items: {
+      create: jest.fn(),
+      query: jest.fn(),
+    },
+  } as any;
+
+  const textClient = {
+    analyzeSentiment: jest.fn(),
+  } as any;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/journals', createJournalRouter(container, textClient));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('saves entry with sentiment', async () => {
+    textClient.analyzeSentiment.mockResolvedValue([{ confidenceScores: { positive: 0.8 } }]);
+    container.items.create.mockResolvedValue({ resource: { id: '1' } });
+
+    const res = await request(app).post('/journals').send({ userId: 'u1', content: 'hello' });
+
+    expect(res.status).toBe(201);
+    expect(textClient.analyzeSentiment).toHaveBeenCalledWith(['hello']);
+    expect(container.items.create).toHaveBeenCalled();
+    expect(res.body.sentimentScore).toBe(0.8);
+  });
+
+  it('retrieves entries', async () => {
+    const entries: JournalEntry[] = [
+      { id: '1', userId: 'u1', content: 'hi', sentimentScore: 0.9, date: 'd' },
+    ];
+    container.items.query.mockReturnValue({ fetchAll: jest.fn().mockResolvedValue({ resources: entries }) });
+
+    const res = await request(app).get('/journals');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(entries);
+  });
+});

--- a/backend/src/journals.ts
+++ b/backend/src/journals.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import { Container } from '@azure/cosmos';
+import { TextAnalyticsClient } from '@azure/ai-text-analytics';
+
+export interface JournalEntry {
+  id: string;
+  userId: string;
+  content: string;
+  date: string;
+  sentimentScore: number;
+}
+
+export function createJournalRouter(container: Container, textClient: TextAnalyticsClient) {
+  const router = Router();
+
+  router.post('/', async (req, res) => {
+    const { userId, content } = req.body;
+    if (!userId || !content) {
+      return res.status(400).json({ message: 'userId and content required' });
+    }
+    try {
+      const [result] = await textClient.analyzeSentiment([content]);
+      const score = result.confidenceScores.positive;
+      const entry: JournalEntry = {
+        id: Date.now().toString(),
+        userId,
+        content,
+        sentimentScore: score,
+        date: new Date().toISOString(),
+      };
+      await container.items.create(entry);
+      res.status(201).json(entry);
+    } catch (err) {
+      res.status(500).json({ message: 'Error saving journal entry' });
+    }
+  });
+
+  router.get('/', async (_req, res) => {
+    try {
+      const { resources } = await container.items
+        .query('SELECT * FROM c')
+        .fetchAll();
+      res.status(200).json(resources as JournalEntry[]);
+    } catch (err) {
+      res.status(500).json({ message: 'Error retrieving entries' });
+    }
+  });
+
+  return router;
+}

--- a/backend/src/types/stubs.d.ts
+++ b/backend/src/types/stubs.d.ts
@@ -6,3 +6,5 @@ declare module 'morgan' { const m: any; export = m; }
 declare module 'dotenv' { const d: any; export = d; }
 declare module 'express-jwt' { export const expressjwt: any; }
 declare module 'jwks-rsa' { const j: any; export = j; }
+declare module '@azure/cosmos' { const c: any; export = c; }
+declare module '@azure/ai-text-analytics' { const a: any; export = a; }


### PR DESCRIPTION
## Summary
- add `JournalEntry` interface per design plans
- use the interface in the journal router and tests

## Testing
- `cd frontend && npm run lint && npm test` *(fails: ESLint config and Jest not found)*
- `cd backend && npm run lint && npm test` *(fails: ESLint config and Jest not found)*
- `cd infra && terraform validate` *(fails: terraform not installed)*